### PR TITLE
Explicitly define actions for CLI call

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 var fs = require("fs");
 var path = require("path");
-var inputDir = input[2];
-var inputMinType = input[3] || "uglifyjs";
+var inputMinType = "uglifyjs";
 var compressor = require("node-minify");
 
 var walk = function(currentDirPath, callback) {
@@ -40,7 +39,9 @@ var minifyAll = function(dir, options, callback){
     });
 };
 if (require.main === module) {
-    var input = process.argv;
+    var input = process.argv, 
+        inputDir = input[2], 
+        inputMinType = input[3] || inputMinType;
     minifyAll(inputDir);
 } else {
     module.exports = minifyAll;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 var fs = require("fs");
 var path = require("path");
-var input = process.argv;
 var inputDir = input[2];
 var inputMinType = input[3] || "uglifyjs";
 var compressor = require("node-minify");
@@ -40,9 +39,9 @@ var minifyAll = function(dir, options, callback){
         }
     });
 };
-
-if (inputDir){
+if (require.main === module) {
+    var input = process.argv;
     minifyAll(inputDir);
+} else {
+    module.exports = minifyAll;
 }
-
-module.exports = minifyAll;


### PR DESCRIPTION
Now, if minifyAll imported from another script, that has it's own command line flags, an error is thrown, because minifyAll treats one of those flags as the path to file and tries to run minification during import (which is also not really proper behavior). 

Instead, minification should be started immediately only if script was called from CLI directly, otherwise minifyAll function exported. 